### PR TITLE
Integrate SIMDE

### DIFF
--- a/XenonRecomp/CMakeLists.txt
+++ b/XenonRecomp/CMakeLists.txt
@@ -11,11 +11,12 @@ add_executable(XenonRecomp
 target_precompile_headers(XenonRecomp PUBLIC "pch.h")
 
 target_link_libraries(XenonRecomp PRIVATE
-    LibXenonAnalyse 
-    XenonUtils 
+    LibXenonAnalyse
+    XenonUtils
     fmt::fmt
-    tomlplusplus::tomlplusplus 
-    xxHash::xxhash)
+    tomlplusplus::tomlplusplus
+    xxHash::xxhash
+    simde)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(XenonRecomp PRIVATE -Wno-switch -Wno-unused-variable -Wno-null-arithmetic)
@@ -26,4 +27,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 endif()
 
-target_compile_definitions(XenonRecomp PRIVATE _CRT_SECURE_NO_WARNINGS)
+target_compile_definitions(XenonRecomp PRIVATE
+    _CRT_SECURE_NO_WARNINGS
+    SIMDE_ENABLE_NATIVE_ALIASES)

--- a/XenonRecomp/pch.h
+++ b/XenonRecomp/pch.h
@@ -16,4 +16,10 @@
 #include <xbox.h>
 #include <xxhash.h>
 #include <fmt/core.h>
-#include <xmmintrin.h>
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86)
+#  include <x86intrin.h>
+#else
+#  define SIMDE_ENABLE_NATIVE_ALIASES
+#  include <simde/x86/xmmintrin.h>
+#  include <simde/x86/smmintrin.h>
+#endif

--- a/XenonUtils/CMakeLists.txt
+++ b/XenonUtils/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(XenonUtils
 target_compile_definitions(XenonUtils
     PRIVATE
         NOMINMAX
+        SIMDE_ENABLE_NATIVE_ALIASES
 )
 
 target_include_directories(XenonUtils 
@@ -25,7 +26,9 @@ target_include_directories(XenonUtils
         "${THIRDPARTY_ROOT}/TinySHA1"
 )
 
-target_link_libraries(XenonUtils 
+target_link_libraries(XenonUtils
     PUBLIC
         disasm
+    PRIVATE
+        simde
 )

--- a/XenonUtils/ppc_context.h
+++ b/XenonUtils/ppc_context.h
@@ -12,13 +12,15 @@
 #include <cstdlib>
 #include <cstring>
 
-#include <x86intrin.h>
-
-#ifdef _WIN32
-#include <intrin.h>
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86)
+#  include <x86intrin.h>
+#  ifdef _WIN32
+#    include <intrin.h>
+#  endif
 #else
-#include <xmmintrin.h>
-#include <smmintrin.h>
+#  define SIMDE_ENABLE_NATIVE_ALIASES
+#  include <simde/x86/xmmintrin.h>
+#  include <simde/x86/smmintrin.h>
 #endif
 
 #define PPC_JOIN(x, y) x##y

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -11,3 +11,6 @@ endif()
 if (NOT TARGET xxHash::xxhash)
     add_subdirectory(${THIRDPARTY_ROOT}/xxHash/cmake_unofficial)
 endif()
+
+add_library(simde INTERFACE)
+target_include_directories(simde INTERFACE ${THIRDPARTY_ROOT}/simde)


### PR DESCRIPTION
## Summary
- expose SIMDE headers from `thirdparty`
- link new target in `XenonUtils` and `XenonRecomp`
- conditionally include x86 intrinsics via SIMDE
- add SIMDE alias compile definition

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: member constructor not allowed in anonymous aggregate)*
- `cmake -B build.arm ...` *(fails: missing aarch64 cross compiler libs)*

------
https://chatgpt.com/codex/tasks/task_e_6868bf321a588325a016cb782d8a3bb9