### PR TITLE
Fix lzxDecompress linkage

### DIFF
--- a/XenonUtils/xex_patcher.cpp
+++ b/XenonUtils/xex_patcher.cpp
@@ -141,7 +141,7 @@ inline bool bitScanForward(uint64_t v, uint32_t *outFirstSetIndex)
 }
 #endif
 
-static int lzxDecompress(const void *lzxData, size_t lzxLength, void *dst, size_t dstLength, uint32_t windowSize, void *windowData, size_t windowDataLength)
+int lzxDecompress(const void *lzxData, size_t lzxLength, void *dst, size_t dstLength, uint32_t windowSize, void *windowData, size_t windowDataLength)
 {
     int resultCode = 1;
     uint32_t windowBits;

--- a/reference/CrackReference/XenonUtils/xex_patcher.cpp
+++ b/reference/CrackReference/XenonUtils/xex_patcher.cpp
@@ -141,7 +141,7 @@ inline bool bitScanForward(uint64_t v, uint32_t *outFirstSetIndex)
 }
 #endif
 
-static int lzxDecompress(const void *lzxData, size_t lzxLength, void *dst, size_t dstLength, uint32_t windowSize, void *windowData, size_t windowDataLength)
+int lzxDecompress(const void *lzxData, size_t lzxLength, void *dst, size_t dstLength, uint32_t windowSize, void *windowData, size_t windowDataLength)
 {
     int resultCode = 1;
     uint32_t windowBits;


### PR DESCRIPTION
## Summary
- remove `static` specifier from `lzxDecompress` definition in both codebases

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target XenonUtils` *(fails: member constructor not allowed in anonymous aggregate)*

------
https://chatgpt.com/codex/tasks/task_e_6868c3fa97f083258aecc876681b29fe